### PR TITLE
Merging some of recent SaveSystem work into dev

### DIFF
--- a/src/Bannerlord.ButterLib.Implementation/ObjectSystem/MBObjectExtensionDataStore.cs
+++ b/src/Bannerlord.ButterLib.Implementation/ObjectSystem/MBObjectExtensionDataStore.cs
@@ -3,7 +3,7 @@
 using Newtonsoft.Json;
 
 using System;
-//using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -13,12 +13,12 @@ using TaleWorlds.SaveSystem;
 
 namespace Bannerlord.ButterLib.Implementation.ObjectSystem
 {
-    internal sealed class MBObjectVariableStorageBehavior : CampaignBehaviorBase, IMBObjectVariableStorage
+    internal sealed class MBObjectExtensionDataStore : CampaignBehaviorBase, IMBObjectExtensionDataStore
     {
         public const int SaveBaseId = 222_444_700; // 10 reserved, should probably base this one the ButterLib range
 
-        private Dictionary<DataKey, object?> _vars = new Dictionary<DataKey, object?>();
-        private Dictionary<DataKey, bool>   _flags = new Dictionary<DataKey, bool>();
+        private ConcurrentDictionary<DataKey, object?> _vars = new ConcurrentDictionary<DataKey, object?>();
+        private ConcurrentDictionary<DataKey, bool>   _flags = new ConcurrentDictionary<DataKey, bool>();
 
         public override void RegisterEvents() { }
 
@@ -53,9 +53,9 @@ namespace Bannerlord.ButterLib.Implementation.ObjectSystem
         /* Variables Implementation */
         public bool HasVariable(MBObjectBase @object, string name) => _vars.ContainsKey(DataKey.Make(@object, name));
 
-        //public bool RemoveVariable(MBObjectBase @object, string name) => _vars.TryRemove(DataKey.Make(@object, name), out _);
+        public bool RemoveVariable(MBObjectBase @object, string name) => _vars.TryRemove(DataKey.Make(@object, name), out _);
 
-        public bool RemoveVariable(MBObjectBase @object, string name) => _vars.Remove(DataKey.Make(@object, name));
+        //public bool RemoveVariable(MBObjectBase @object, string name) => _vars.Remove(DataKey.Make(@object, name));
 
         public void SetVariable(MBObjectBase @object, string name, object? data) => _vars[DataKey.Make(@object, name)] = data;
 
@@ -75,9 +75,9 @@ namespace Bannerlord.ButterLib.Implementation.ObjectSystem
 
         public bool HasFlag(MBObjectBase @object, string name) => _flags.ContainsKey(DataKey.Make(@object, name));
 
-        //public bool RemoveFlag(MBObjectBase @object, string name) => _flags.TryRemove(DataKey.Make(@object, name), out _);
+        public bool RemoveFlag(MBObjectBase @object, string name) => _flags.TryRemove(DataKey.Make(@object, name), out _);
 
-        public bool RemoveFlag(MBObjectBase @object, string name) => _flags.Remove(DataKey.Make(@object, name));
+        //public bool RemoveFlag(MBObjectBase @object, string name) => _flags.Remove(DataKey.Make(@object, name));
 
         public void SetFlag(MBObjectBase @object, string name) => _flags[DataKey.Make(@object, name)] = true;
 
@@ -95,7 +95,7 @@ namespace Bannerlord.ButterLib.Implementation.ObjectSystem
 
             internal static DataKey Make(MBObjectBase obj, string key) => new DataKey(obj.Id, key);
 
-            public bool Equals(StorageKey other) => ObjectId == other.ObjectId && Key is not null! && other.Key is not null! && Key.Equals(other.Key);
+            public bool Equals(DataKey other) => ObjectId == other.ObjectId && !(Key is null || other.Key is null) && Key.Equals(other.Key);
 
             public override bool Equals(object? obj) => obj is DataKey k && Equals(k);
 
@@ -113,8 +113,8 @@ namespace Bannerlord.ButterLib.Implementation.ObjectSystem
             protected override void DefineGenericStructDefinitions() { }
             protected override void DefineContainerDefinitions()
             {
-                ConstructContainerDefinition(typeof(Dictionary<DataKey, object?>));
-                ConstructContainerDefinition(typeof(Dictionary<DataKey, bool>));
+                ConstructContainerDefinition(typeof(ConcurrentDictionary<DataKey, object?>));
+                ConstructContainerDefinition(typeof(ConcurrentDictionary<DataKey, bool>));
             }
         }
     }

--- a/src/Bannerlord.ButterLib.Implementation/ObjectSystem/MBObjectExtensionDataStore.cs
+++ b/src/Bannerlord.ButterLib.Implementation/ObjectSystem/MBObjectExtensionDataStore.cs
@@ -1,7 +1,5 @@
 ﻿using Bannerlord.ButterLib.ObjectSystem;
 
-using Newtonsoft.Json;
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Bannerlord.ButterLib.Implementation/ObjectSystem/MBObjectVariableStorageBehavior.cs
+++ b/src/Bannerlord.ButterLib.Implementation/ObjectSystem/MBObjectVariableStorageBehavior.cs
@@ -3,7 +3,7 @@
 using Newtonsoft.Json;
 
 using System;
-using System.Collections.Concurrent;
+//using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -17,8 +17,8 @@ namespace Bannerlord.ButterLib.Implementation.ObjectSystem
     {
         public const int SaveBaseId = 222_444_700; // 10 reserved, should probably base this one the ButterLib range
 
-        private Dictionary<StorageKey, object?> _vars = new Dictionary<StorageKey, object?>();
-        private Dictionary<StorageKey, bool>   _flags = new Dictionary<StorageKey, bool>();
+        private Dictionary<DataKey, object?> _vars = new Dictionary<DataKey, object?>();
+        private Dictionary<DataKey, bool>   _flags = new Dictionary<DataKey, bool>();
 
         public override void RegisterEvents() { }
 
@@ -34,8 +34,8 @@ namespace Bannerlord.ButterLib.Implementation.ObjectSystem
                 ReleaseOrphanedEntries(_flags, expiredIdCache);
             }
 
-            //dataStore.SyncData("Vars", ref _vars);
-            //dataStore.SyncData("Flags", ref _flags);
+            dataStore.SyncData("Vars", ref _vars);
+            dataStore.SyncData("Flags", ref _flags);
         }
 
         private static void ReleaseOrphanedEntries<TVal>(IDictionary<StorageKey, TVal> dict, IDictionary<uint, bool> expiredIds)

--- a/src/Bannerlord.ButterLib.Implementation/ObjectSystem/MBObjectVariableStorageBehavior.cs
+++ b/src/Bannerlord.ButterLib.Implementation/ObjectSystem/MBObjectVariableStorageBehavior.cs
@@ -1,5 +1,4 @@
 ﻿using Bannerlord.ButterLib.ObjectSystem;
-using Bannerlord.ButterLib.SaveSystem.Extensions;
 
 using Newtonsoft.Json;
 

--- a/src/Bannerlord.ButterLib.Implementation/ObjectSystem/MBObjectVariableStorageBehavior.cs
+++ b/src/Bannerlord.ButterLib.Implementation/ObjectSystem/MBObjectVariableStorageBehavior.cs
@@ -62,7 +62,7 @@ namespace Bannerlord.ButterLib.Implementation.ObjectSystem
             protected override void DefineContainerDefinitions()
             {
                 ConstructContainerDefinition(typeof(ConcurrentDictionary<StorageKey, object?>));
-                ConstructContainerDefinition(typeof(ConcurrentDictionary<StorageKey, uint>));
+                ConstructContainerDefinition(typeof(ConcurrentDictionary<StorageKey, bool>));
             }
         }
 

--- a/src/Bannerlord.ButterLib.Implementation/ObjectSystem/Patches/CampaignBehaviorManagerPatch.cs
+++ b/src/Bannerlord.ButterLib.Implementation/ObjectSystem/Patches/CampaignBehaviorManagerPatch.cs
@@ -22,29 +22,29 @@ namespace Bannerlord.ButterLib.Implementation.ObjectSystem.Patches
         private delegate void SaveBehaviorDataDelegate(CampaignBehaviorBase campaignBehavior);
         private delegate void LoadBehaviorDataDelegate(CampaignBehaviorBase campaignBehavior);
 
-        private static ILogger _logger = default!;
+        private static ILogger _log = default!;
 
         // Application:
 
         internal static void Apply(Harmony harmony)
         {
-            _logger = ButterLibSubModule.Instance?.GetServiceProvider()?.GetRequiredService<ILogger<CampaignBehaviorManagerPatch>>() ??
+            _log = ButterLibSubModule.Instance?.GetServiceProvider()?.GetRequiredService<ILogger<CampaignBehaviorManagerPatch>>() ??
                 NullLogger<CampaignBehaviorManagerPatch>.Instance;
 
             if (OnGameLoadedTargetMI is null)
-                _logger.LogError($"{nameof(OnGameLoadedTargetMI)} is null");
+                _log.LogError($"{nameof(OnGameLoadedTargetMI)} is null");
             if (OnBeforeSaveTargetMI is null)
-                _logger.LogError($"{nameof(OnBeforeSaveTargetMI)} is null");
+                _log.LogError($"{nameof(OnBeforeSaveTargetMI)} is null");
             if (OnGameLoadedPatchMI is null)
-                _logger.LogError($"{nameof(OnGameLoadedPatchMI)} is null");
+                _log.LogError($"{nameof(OnGameLoadedPatchMI)} is null");
             if (OnBeforeSavePatchMI is null)
-                _logger.LogError($"{nameof(OnBeforeSavePatchMI)} is null");
+                _log.LogError($"{nameof(OnBeforeSavePatchMI)} is null");
             if (LoadBehaviorDataMI is null)
-                _logger.LogError($"{nameof(LoadBehaviorDataMI)} is null");
+                _log.LogError($"{nameof(LoadBehaviorDataMI)} is null");
             if (SaveBehaviorDataMI is null)
-                _logger.LogError($"{nameof(SaveBehaviorDataMI)} is null");
+                _log.LogError($"{nameof(SaveBehaviorDataMI)} is null");
             if (CampaignBehaviorDataStoreT is null)
-                _logger.LogError($"{nameof(CampaignBehaviorDataStoreT)} is null");
+                _log.LogError($"{nameof(CampaignBehaviorDataStoreT)} is null");
 
             if (OnGameLoadedTargetMI is null || OnBeforeSaveTargetMI is null ||
                 OnGameLoadedPatchMI is null  || OnBeforeSavePatchMI is null  ||
@@ -84,23 +84,23 @@ namespace Bannerlord.ButterLib.Implementation.ObjectSystem.Patches
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void OnGameLoadedPrefix(object? ____campaignBehaviorDataStore)
         {
-            var mbObjectVariableStorage = ButterLibSubModule.Instance?.GetServiceProvider()?.GetRequiredService<IMBObjectVariableStorage>();
+            var mbObjectVariableStorage = ButterLibSubModule.Instance?.GetServiceProvider()?.GetRequiredService<IMBObjectExtensionDataStore>();
 
             if (mbObjectVariableStorage is null)
             {
-                _logger.LogError($"{nameof(OnGameLoadedPrefix)}: {nameof(mbObjectVariableStorage)} is null");
+                _log.LogError($"{nameof(OnGameLoadedPrefix)}: {nameof(mbObjectVariableStorage)} is null");
                 return;
             }
 
             if (!(mbObjectVariableStorage is CampaignBehaviorBase storageBehavior))
             {
-                _logger.LogError($"{nameof(OnGameLoadedPrefix)}: {nameof(mbObjectVariableStorage)} is not a CampaignBehaviorBase");
+                _log.LogError($"{nameof(OnGameLoadedPrefix)}: {nameof(mbObjectVariableStorage)} is not a CampaignBehaviorBase");
                 return;
             }
 
             if (____campaignBehaviorDataStore is null)
             {
-                _logger.LogError($"{nameof(OnGameLoadedPrefix)}: {nameof(____campaignBehaviorDataStore)} is null");
+                _log.LogError($"{nameof(OnGameLoadedPrefix)}: {nameof(____campaignBehaviorDataStore)} is null");
                 return;
             }
 
@@ -111,23 +111,23 @@ namespace Bannerlord.ButterLib.Implementation.ObjectSystem.Patches
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void OnBeforeSavePostfix(object? ____campaignBehaviorDataStore)
         {
-            var mbObjectVariableStorage = ButterLibSubModule.Instance?.GetServiceProvider()?.GetRequiredService<IMBObjectVariableStorage>();
+            var mbObjectVariableStorage = ButterLibSubModule.Instance?.GetServiceProvider()?.GetRequiredService<IMBObjectExtensionDataStore>();
 
             if (mbObjectVariableStorage is null)
             {
-                _logger.LogError($"{nameof(OnBeforeSavePostfix)}: {nameof(mbObjectVariableStorage)} is null");
+                _log.LogError($"{nameof(OnBeforeSavePostfix)}: {nameof(mbObjectVariableStorage)} is null");
                 return;
             }
 
             if (!(mbObjectVariableStorage is CampaignBehaviorBase storageBehavior))
             {
-                _logger.LogError($"{nameof(OnBeforeSavePostfix)}: {nameof(mbObjectVariableStorage)} is not a CampaignBehaviorBase");
+                _log.LogError($"{nameof(OnBeforeSavePostfix)}: {nameof(mbObjectVariableStorage)} is not a CampaignBehaviorBase");
                 return;
             }
 
             if (____campaignBehaviorDataStore is null)
             {
-                _logger.LogError($"{nameof(OnBeforeSavePostfix)}: {nameof(____campaignBehaviorDataStore)} is null");
+                _log.LogError($"{nameof(OnBeforeSavePostfix)}: {nameof(____campaignBehaviorDataStore)} is null");
                 return;
             }
 

--- a/src/Bannerlord.ButterLib.Implementation/SaveSystem/Patches/DefinitionContextPatch.cs
+++ b/src/Bannerlord.ButterLib.Implementation/SaveSystem/Patches/DefinitionContextPatch.cs
@@ -145,7 +145,7 @@ namespace Bannerlord.ButterLib.Implementation.SaveSystem.Patches
             if (obj is null)
             {
                 var prefix = errPrefix is null ? string.Empty : errPrefix;
-                _log.LogError($"{errPrefix}{name} is null!");
+                _log.LogError($"{prefix}{name} is null!");
                 return false;
             }
 

--- a/src/Bannerlord.ButterLib.Implementation/SaveSystem/Patches/DefinitionContextPatch.cs
+++ b/src/Bannerlord.ButterLib.Implementation/SaveSystem/Patches/DefinitionContextPatch.cs
@@ -144,7 +144,7 @@ namespace Bannerlord.ButterLib.Implementation.SaveSystem.Patches
         {
             if (obj is null)
             {
-                var prefix = errPrefix is null ? string.Empty : errPrefix;
+                var prefix = errPrefix ?? string.Empty;
                 _log.LogError($"{prefix}{name} is null!");
                 return false;
             }

--- a/src/Bannerlord.ButterLib.Implementation/SaveSystem/Patches/DefinitionContextPatch.cs
+++ b/src/Bannerlord.ButterLib.Implementation/SaveSystem/Patches/DefinitionContextPatch.cs
@@ -1,4 +1,5 @@
 ﻿using Bannerlord.ButterLib.Common.Extensions;
+using Bannerlord.ButterLib.Common.Helpers;
 
 using HarmonyLib;
 
@@ -42,40 +43,54 @@ namespace Bannerlord.ButterLib.Implementation.SaveSystem.Patches
             _log = ButterLibSubModule.Instance?.GetServiceProvider()?.GetRequiredService<ILogger<DefinitionContextPatch>>()
                    ?? NullLogger<DefinitionContextPatch>.Instance;
 
-            return Patches.Select(p => p.IsReady).All(ready => ready) && Patches.All(p => p.ApplyPrefix(harmony));
+            return Patches.Select(p => p.IsReady).All(ready => ready) && Patches.All(p => p.Apply(harmony));
         }
-
 
         // PATCH DEFINITIONS
 
         private class NoType { }
-        private static readonly Type? TargetType = typeof(MetaData).Assembly.GetType("TaleWorlds.SaveSystem.Definition.DefinitionContext");
+
+        private delegate bool IsContainerDelegate(Type type);
+        private static readonly Assembly TargetAssembly = typeof(ContainerType).Assembly;
+        private static readonly Type? TargetType = TargetAssembly.GetType("TaleWorlds.SaveSystem.Definition.DefinitionContext");
+        private static readonly Type? TypeExtensionsType = TargetAssembly.GetType("TaleWorlds.SaveSystem.TypeExtensions");
+        private static readonly MethodInfo? IsContainerMethod = AccessTools.Method(TypeExtensionsType ?? typeof(NoType), "IsContainer", new[] { typeof(Type) });
+        private static readonly IsContainerDelegate? IsContainer = AccessTools2.GetDelegate<IsContainerDelegate>(IsContainerMethod);
 
         private static MethodInfo? TargetTypeMethod(string name) => AccessTools.Method(TargetType ?? typeof(NoType), name);
 
-        private static readonly Patch[] Patches = new Patch[]
+        private sealed class ConstructContainerDefinitionPrefixPatch : PrefixPatch
         {
-            new("AddRootClassDefinitionPrefix",     TargetTypeMethod("AddRootClassDefinition")),
-            new("AddClassDefinitionPrefix",         TargetTypeMethod("AddClassDefinition")),
-            new("AddStructDefinitionPrefix",        TargetTypeMethod("AddStructDefinition")),
-            new("AddInterfaceDefinitionPrefix",     TargetTypeMethod("AddInterfaceDefinition")),
-            new("AddEnumDefinitionPrefix",          TargetTypeMethod("AddEnumDefinition")),
-            new("AddContainerDefinitionPrefix",     TargetTypeMethod("AddContainerDefinition")),
-            new("AddBasicTypeDefinitionPrefix",     TargetTypeMethod("AddBasicTypeDefinition")),
-            new("AddGenericClassDefinitionPrefix",  TargetTypeMethod("AddGenericClassDefinition")),
-            new("AddGenericStructDefinitionPrefix", TargetTypeMethod("AddGenericStructDefinition")),
+            internal ConstructContainerDefinitionPrefixPatch()
+                : base(nameof(ConstructContainerDefinitionPrefix), TargetTypeMethod("ConstructContainerDefinition")) { }
+
+            internal override bool IsReady => base.IsReady & ThisNotNull(IsContainer, $"{nameof(IsContainer)} delegate");
+        }
+
+        private static readonly Patch[] Patches = new PrefixPatch[]
+        {
+            new(nameof(AddBasicTypeDefinitionPrefix),     TargetTypeMethod("AddBasicTypeDefinition")),
+            new(nameof(AddClassDefinitionPrefix),         TargetTypeMethod("AddClassDefinition")),
+            new(nameof(AddStructDefinitionPrefix),        TargetTypeMethod("AddStructDefinition")),
+            new(nameof(AddInterfaceDefinitionPrefix),     TargetTypeMethod("AddInterfaceDefinition")),
+            new(nameof(AddEnumDefinitionPrefix),          TargetTypeMethod("AddEnumDefinition")),
+            new(nameof(AddRootClassDefinitionPrefix),     TargetTypeMethod("AddRootClassDefinition")),
+            new(nameof(AddGenericClassDefinitionPrefix),  TargetTypeMethod("AddGenericClassDefinition")),
+            new(nameof(AddGenericStructDefinitionPrefix), TargetTypeMethod("AddGenericStructDefinition")),
+            new(nameof(AddContainerDefinitionPrefix),     TargetTypeMethod("AddContainerDefinition")),
+            new ConstructContainerDefinitionPrefixPatch(),
         };
 
         // PATCH METHODS
 
         private static bool CanAddTypeDefinition(TypeDefinitionBase? typeDef, Dictionary<Type, TypeDefinitionBase> typeDict)
         {
-            if (typeDef is null)
+            if (typeDef is null || typeDef.Type is null)
                 return false;
 
             if (typeDict.ContainsKey(typeDef.Type))
             {
-                _log.LogTrace("Suppressed duplicate SaveSystem registration of type {type}", typeDef.Type.FullName);
+                _log.LogTrace("Suppressed duplicate definition of serializable type: {type}", typeDef.Type.FullName);
                 return false;
             }
 
@@ -118,26 +133,49 @@ namespace Bannerlord.ButterLib.Implementation.SaveSystem.Patches
                                                              Dictionary<Type, TypeDefinitionBase> ____allTypeDefinitions) =>
             CanAddTypeDefinition(genericStructDefinition, ____allTypeDefinitions);
 
-        // UTILITY
+        /*
+         * <summary>
+         * Prevent <c>DefinitionContext.ConstructContainerDefinition</c> from executing if the given
+         * <see cref="Type"> is not a supported container type.
+         * </summary>
+         * <remarks>
+         * The target method fails to check all used values of the <see cref="ContainerType"> enum;
+         * specifically, it does not check for the value <c>None</c>. Thus, it can easily add alleged
+         * container type definitions to the <c>DefinitionContext</c> whose fields are, besides the
+         * <see cref="Type">, entirely null. If this happens, the game will later crash.
+         * </remarks>
+         */
+        private static bool ConstructContainerDefinitionPrefix(Type type) => type is not null && IsContainer!(type);
 
-        private class Patch
+        // INSTRUMENTATION
+
+        private abstract class Patch
         {
-            internal readonly string      PatchMethodName;
+            internal readonly string PatchMethodName;
             internal readonly MethodInfo? PatchMethod;
             internal readonly MethodInfo? TargetMethod;
 
             internal Patch(string patchMethodName, MethodInfo? targetMethod)
             {
                 PatchMethodName = patchMethodName;
-                PatchMethod = AccessTools.Method(typeof(DefinitionContextPatch), patchMethodName);
+                PatchMethod = ResolvePatchMethod();
                 TargetMethod = targetMethod;
             }
 
-            internal bool ApplyPrefix(Harmony harmony) => harmony.Patch(TargetMethod, prefix: new HarmonyMethod(PatchMethod)) is not null;
+            internal abstract bool Apply(Harmony harmony);
 
-            internal bool IsReady => MethodNotNull(PatchMethod, nameof(PatchMethod)) & MethodNotNull(TargetMethod, nameof(TargetMethod));
+            internal virtual bool IsReady => ThisNotNull(PatchMethod, nameof(PatchMethod)) & ThisNotNull(TargetMethod, nameof(TargetMethod));
 
-            private bool MethodNotNull(MethodInfo? method, string methodName) => NotNull(method, methodName, $"Patch {PatchMethodName}: ");
+            protected virtual MethodInfo ResolvePatchMethod() => AccessTools.Method(GetType().DeclaringType, PatchMethodName);
+
+            protected bool ThisNotNull(object? obj, string objName) => NotNull(obj, objName, $"Patch {PatchMethodName}: ");
+        }
+
+        private class PrefixPatch : Patch
+        {
+            internal PrefixPatch(string patchMethodName, MethodInfo? targetMethod) : base(patchMethodName, targetMethod) { }
+
+            internal override bool Apply(Harmony harmony) => harmony.Patch(TargetMethod, prefix: new HarmonyMethod(PatchMethod)) is not null;
         }
 
         private static bool NotNull<T>(T obj, string name, string? errPrefix = null) where T : class?

--- a/src/Bannerlord.ButterLib.Implementation/SaveSystem/Patches/DefinitionContextPatch.cs
+++ b/src/Bannerlord.ButterLib.Implementation/SaveSystem/Patches/DefinitionContextPatch.cs
@@ -1,0 +1,146 @@
+﻿using Bannerlord.ButterLib.Common.Extensions;
+
+using HarmonyLib;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using TaleWorlds.SaveSystem;
+using TaleWorlds.SaveSystem.Definition;
+
+namespace Bannerlord.ButterLib.Implementation.SaveSystem.Patches
+{
+    /*
+     * <summary>
+     * Patches all the methods in DefinitionContext which add a new type definition from a SaveableTypeDefiner to only
+     * execute if the given type is not already registered.
+     * </summary>
+     * <remarks>
+     * <para>
+     * This prevents unpredictable save [partial] failures (game reports a saving error, yet saves it anyway).
+     * Further, it prevents a crash when trying to load one of such savegames.
+     * </para>
+     * <para>
+     * In the face of mods, it's impossible for a programmer to know whether a type has already been defined elsewhere
+     * (and also ridiculous to ask any programmer to always know what types have already been defined in the base game).
+     * These patches fully resolve such issues.
+     * </para>
+     * </remarks>
+     */
+    internal sealed class DefinitionContextPatch
+    {
+        private static ILogger _log = default!;
+
+        internal static bool Apply(Harmony harmony)
+        {
+            _log = ButterLibSubModule.Instance?.GetServiceProvider()?.GetRequiredService<ILogger<DefinitionContextPatch>>()
+                   ?? NullLogger<DefinitionContextPatch>.Instance;
+
+            return Patch.AllReady(Patches) && Patches.All(p => p.ApplyPrefix(harmony));
+        }
+
+
+        // PATCH DEFINITIONS
+
+        private class NoType { }
+        private static readonly Type? TargetType = typeof(MetaData).Assembly.GetType("TaleWorlds.SaveSystem.Definition.DefinitionContext");
+
+        private static MethodInfo? TargetTypeMethod(string name) => AccessTools.Method(TargetType ?? typeof(NoType), name);
+
+        private static readonly Patch[] Patches = new[]
+        {
+            new Patch("AddRootClassDefinitionPrefix", TargetTypeMethod("AddRootClassDefinition")),
+            new Patch("AddClassDefinitionPrefix", TargetTypeMethod("AddClassDefinition")),
+            new Patch("AddStructDefinitionPrefix", TargetTypeMethod("AddStructDefinition")),
+            new Patch("AddInterfaceDefinitionPrefix", TargetTypeMethod("AddInterfaceDefinition")),
+            new Patch("AddEnumDefinitionPrefix", TargetTypeMethod("AddEnumDefinition")),
+            new Patch("AddContainerDefinitionPrefix", TargetTypeMethod("AddContainerDefinition")),
+            new Patch("AddBasicTypeDefinitionPrefix", TargetTypeMethod("AddBasicTypeDefinition")),
+            new Patch("AddGenericClassDefinitionPrefix", TargetTypeMethod("AddGenericClassDefinition")),
+            new Patch("AddGenericStructDefinitionPrefix", TargetTypeMethod("AddGenericStructDefinition")),
+        };
+
+        // PATCH METHODS
+
+        private static bool CanAddTypeDefinition(TypeDefinitionBase? typeDef, Dictionary<Type, TypeDefinitionBase> typeDict) =>
+            typeDef is { } && typeDict.ContainsKey(typeDef.Type);
+
+        private static bool AddRootClassDefinitionPrefix(TypeDefinition? rootClassDefinition,
+                                                         Dictionary<Type, TypeDefinitionBase> ____allTypeDefinitions) =>
+            CanAddTypeDefinition(rootClassDefinition, ____allTypeDefinitions);
+
+        private static bool AddClassDefinitionPrefix(TypeDefinition? classDefinition,
+                                                     Dictionary<Type, TypeDefinitionBase> ____allTypeDefinitions) =>
+            CanAddTypeDefinition(classDefinition, ____allTypeDefinitions);
+
+        private static bool AddStructDefinitionPrefix(TypeDefinition? structDefinition,
+                                                      Dictionary<Type, TypeDefinitionBase> ____allTypeDefinitions) =>
+            CanAddTypeDefinition(structDefinition, ____allTypeDefinitions);
+
+        private static bool AddInterfaceDefinitionPrefix(TypeDefinitionBase? interfaceDefinition,
+                                                         Dictionary<Type, TypeDefinitionBase> ____allTypeDefinitions) =>
+            CanAddTypeDefinition(interfaceDefinition, ____allTypeDefinitions);
+
+        private static bool AddEnumDefinitionPrefix(TypeDefinitionBase? enumDefinition,
+                                                    Dictionary<Type, TypeDefinitionBase> ____allTypeDefinitions) =>
+            CanAddTypeDefinition(enumDefinition, ____allTypeDefinitions);
+
+        private static bool AddContainerDefinitionPrefix(ContainerDefinition? containerDefinition,
+                                                         Dictionary<Type, TypeDefinitionBase> ____allTypeDefinitions) =>
+            CanAddTypeDefinition(containerDefinition, ____allTypeDefinitions);
+
+        private static bool AddBasicTypeDefinitionPrefix(TypeDefinitionBase? basicTypeDefinition,
+                                                         Dictionary<Type, TypeDefinitionBase> ____allTypeDefinitions) =>
+            CanAddTypeDefinition(basicTypeDefinition, ____allTypeDefinitions);
+
+        private static bool AddGenericClassDefinitionPrefix(TypeDefinitionBase? genericClassDefinition,
+                                                            Dictionary<Type, TypeDefinitionBase> ____allTypeDefinitions) =>
+            CanAddTypeDefinition(genericClassDefinition, ____allTypeDefinitions);
+
+        private static bool AddGenericStructDefinitionPrefix(TypeDefinitionBase? genericStructDefinition,
+                                                             Dictionary<Type, TypeDefinitionBase> ____allTypeDefinitions) =>
+            CanAddTypeDefinition(genericStructDefinition, ____allTypeDefinitions);
+
+        // UTILITY
+
+        private class Patch
+        {
+            internal readonly string      PatchMethodName;
+            internal readonly MethodInfo? PatchMethod;
+            internal readonly MethodInfo? TargetMethod;
+
+            internal Patch(string patchMethodName, MethodInfo? targetMethod)
+            {
+                PatchMethodName = patchMethodName;
+                PatchMethod = AccessTools.Method(typeof(DefinitionContextPatch), patchMethodName);
+                TargetMethod = targetMethod;
+            }
+
+            internal bool ApplyPrefix(Harmony harmony) => harmony.Patch(TargetMethod, prefix: new HarmonyMethod(PatchMethod)) is { };
+
+            internal bool IsReady() => MethodNotNull(PatchMethod, nameof(PatchMethod)) & MethodNotNull(TargetMethod, nameof(TargetMethod));
+
+            internal static bool AllReady(IEnumerable<Patch> patches) => patches.Select(p => p.IsReady()).All(ready => ready);
+
+            private bool MethodNotNull(MethodInfo? method, string methodName) => NotNull(method, methodName, $"Patch {PatchMethodName}: ");
+        }
+
+        private static bool NotNull<T>(T obj, string name, string? errPrefix = null) where T : class?
+        {
+            if (obj is null)
+            {
+                var prefix = errPrefix is null ? string.Empty : errPrefix;
+                _log.LogError($"{errPrefix}{name} is null!");
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Bannerlord.ButterLib.Implementation/SaveSystem/Patches/TypeExtensionsPatch.cs
+++ b/src/Bannerlord.ButterLib.Implementation/SaveSystem/Patches/TypeExtensionsPatch.cs
@@ -34,12 +34,13 @@ namespace Bannerlord.ButterLib.Implementation.SaveSystem.Patches
                    ?? NullLogger<TypeExtensionsPatch>.Instance;
 
             return NotNull(TargetType, nameof(TargetType))
-                && NotNull(TargetMethod, nameof(TargetMethod))
-                && NotNull(PatchMethod, nameof(PatchMethod))
-                && harmony.Patch(TargetMethod, prefix: new HarmonyMethod(PatchMethod)) is { };
+                 & NotNull(TargetMethod, nameof(TargetMethod))
+                 & NotNull(PatchMethod, nameof(PatchMethod))
+                && harmony.Patch(TargetMethod, prefix: new HarmonyMethod(PatchMethod)) is not null;
         }
 
         private class NoType { }
+
         private static readonly Type? TargetType = typeof(MetaData).Assembly.GetType("TaleWorlds.SaveSystem.TypeExtensions");
         private static readonly Type[] TargetMethodParams = new[] { typeof(Type), typeof(ContainerType).MakeByRefType() };
         private static readonly MethodInfo? TargetMethod = AccessTools.Method(TargetType ?? typeof(NoType), "IsContainer", TargetMethodParams);

--- a/src/Bannerlord.ButterLib.Implementation/SaveSystem/Patches/TypeExtensionsPatch.cs
+++ b/src/Bannerlord.ButterLib.Implementation/SaveSystem/Patches/TypeExtensionsPatch.cs
@@ -1,0 +1,79 @@
+﻿using Bannerlord.ButterLib.Common.Extensions;
+
+using HarmonyLib;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+
+using TaleWorlds.SaveSystem;
+
+namespace Bannerlord.ButterLib.Implementation.SaveSystem.Patches
+{
+    /*
+     * <summary>
+     * Replaces TaleWorlds.SaveSystem.TypeExtensions.IsContainer(this Type, out ContainerType)
+     * </summary>
+     * <remarks>
+     * Our implementation is much more flexible and allows for the SaveSystem to support many more types of containers
+     * in a safe way (i.e., no issues with the deserialization of these containers if ButterLib is removed).
+     * </remarks>
+     */
+    internal sealed class TypeExtensionsPatch
+    {
+        private static ILogger _log = default!;
+
+        internal static bool Apply(Harmony harmony)
+        {
+            _log = ButterLibSubModule.Instance?.GetServiceProvider()?.GetRequiredService<ILogger<TypeExtensionsPatch>>()
+                   ?? NullLogger<TypeExtensionsPatch>.Instance;
+
+            return NotNull(TargetType, nameof(TargetType))
+                && NotNull(TargetMethod, nameof(TargetMethod))
+                && NotNull(PatchMethod, nameof(PatchMethod))
+                && harmony.Patch(TargetMethod, prefix: new HarmonyMethod(PatchMethod)) is { };
+        }
+
+        private class NoType { }
+        private static readonly Type? TargetType = typeof(MetaData).Assembly.GetType("TaleWorlds.SaveSystem.TypeExtensions");
+        private static readonly Type[] TargetMethodParams = new[] { typeof(Type), typeof(ContainerType).MakeByRefType() };
+        private static readonly MethodInfo? TargetMethod = AccessTools.Method(TargetType ?? typeof(NoType), "IsContainer", TargetMethodParams);
+        private static readonly MethodInfo? PatchMethod = AccessTools.Method(typeof(TypeExtensionsPatch), "IsContainerPrefix");
+
+        private static bool IsContainerPrefix(Type type, out ContainerType containerType, ref bool __result)
+        {
+            containerType = ContainerType.None;
+
+            if (type.IsGenericType && !type.IsGenericTypeDefinition)
+                type = type.GetGenericTypeDefinition();
+
+            if (type.IsArray)
+                containerType = ContainerType.Array;
+            else if (typeof(IDictionary).IsAssignableFrom(type))
+                containerType = ContainerType.Dictionary;
+            else if (typeof(IList).IsAssignableFrom(type))
+                containerType = ContainerType.List;
+            else if (type == typeof(Queue<>) || type == typeof(Queue))
+                containerType = ContainerType.Queue; // Piggybacking ICollection<T> on to the "Queue" category is phase 2
+
+            __result = containerType != ContainerType.None;
+            return false;
+        }
+
+        private static bool NotNull<T>(T obj, string name) where T : class?
+        {
+            if (obj is null)
+            {
+                _log.LogError($"{name} is null!");
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Bannerlord.ButterLib.Implementation/SubModule.cs
+++ b/src/Bannerlord.ButterLib.Implementation/SubModule.cs
@@ -35,7 +35,7 @@ namespace Bannerlord.ButterLib.Implementation
             base.OnSubModuleLoad();
 
             Logger = this.GetTempServiceProvider().GetRequiredService<ILogger<SubModule>>();
-            Logger.LogTrace("OnSubModuleLoad() started tracking.");
+            Logger.LogTrace("ButterLib.Implementation: OnSubModuleLoad");
 
             Logger.LogInformation("Wrapping DebugManager of type {type} with DebugManagerWrapper.", Debug.DebugManager.GetType());
             Debug.DebugManager = new DebugManagerWrapper(Debug.DebugManager, this.GetTempServiceProvider()!);
@@ -49,13 +49,13 @@ namespace Bannerlord.ButterLib.Implementation
             services.AddTransient<ICampaignDescriptorProvider, JsonCampaignDescriptorProvider>();
             services.AddScoped<IMBObjectExtensionDataStore, MBObjectExtensionDataStore>();
 
-            Logger.LogTrace("OnSubModuleLoad() finished.");
+            Logger.LogTrace("ButterLib.Implementation: OnSubModuleLoad: Done");
         }
 
         protected override void OnBeforeInitialModuleScreenSetAsRoot()
         {
             base.OnBeforeInitialModuleScreenSetAsRoot();
-            Logger.LogTrace("OnBeforeInitialModuleScreenSetAsRoot() started.");
+            Logger.LogTrace("ButterLib.Implementation: OnBeforeInitialModuleScreenSetAsRoot");
 
             if (FirstInit)
             {
@@ -85,13 +85,13 @@ namespace Bannerlord.ButterLib.Implementation
                 DefinitionContextPatch.Apply(saveSystemHarmony); // Fixes save corruption & crashes when duplicate types are defined
             }
 
-            Logger.LogTrace("OnBeforeInitialModuleScreenSetAsRoot() finished.");
+            Logger.LogTrace("ButterLib.Implementation: OnBeforeInitialModuleScreenSetAsRoot: Done");
         }
 
         protected override void OnGameStart(Game game, IGameStarter gameStarterObject)
         {
             base.OnGameStart(game, gameStarterObject);
-            Logger.LogTrace("OnGameStart(Game, IGameStarter) started.");
+            Logger.LogTrace("ButterLib.Implementation: OnGameStart");
 
             if (game.GameType is Campaign)
             {
@@ -102,20 +102,20 @@ namespace Bannerlord.ButterLib.Implementation
                 gameStarter.AddBehavior(new GeopoliticsCachingBehavior());
             }
 
-            Logger.LogTrace("OnGameStart(Game, IGameStarter) finished.");
+            Logger.LogTrace("ButterLib.Implementation: OnGameStart: Done");
         }
 
         public override void OnGameEnd(Game game)
         {
             base.OnGameEnd(game);
-            Logger.LogTrace("OnGameEnd(Game) started.");
+            Logger.LogTrace("ButterLib.Implementation: OnGameEnd");
 
             if (game.GameType is Campaign)
             {
                 CampaignIdentifierEvents.Instance = null;
             }
 
-            Logger.LogTrace("OnGameEnd(Game) finished.");
+            Logger.LogTrace("ButterLib.Implementation: OnGameEnd: Done");
         }
     }
 }

--- a/src/Bannerlord.ButterLib.Implementation/SubModule.cs
+++ b/src/Bannerlord.ButterLib.Implementation/SubModule.cs
@@ -9,6 +9,7 @@ using Bannerlord.ButterLib.Implementation.DistanceMatrix;
 using Bannerlord.ButterLib.Implementation.Logging;
 using Bannerlord.ButterLib.Implementation.ObjectSystem;
 using Bannerlord.ButterLib.Implementation.ObjectSystem.Patches;
+using Bannerlord.ButterLib.Implementation.SaveSystem.Patches;
 using Bannerlord.ButterLib.ObjectSystem;
 
 using HarmonyLib;
@@ -80,6 +81,7 @@ namespace Bannerlord.ButterLib.Implementation
                 // Selectively apply Harmony patches for MBObjectVariableStorageBehavior load/save
                 // Moved to OnBeforeInitialModuleScreenSetAsRoot so we'll get a final logger
                 CampaignBehaviorManagerPatch.Apply(new Harmony("Bannerlord.ButterLib.MBObjectVariableStorage"));
+                TypeExtensionsPatch.Apply(new Harmony("Bannerlord.ButterLib.SaveSystem"));
             }
 
             Logger.LogTrace("OnBeforeInitialModuleScreenSetAsRoot() finished.");

--- a/src/Bannerlord.ButterLib.Implementation/SubModule.cs
+++ b/src/Bannerlord.ButterLib.Implementation/SubModule.cs
@@ -79,7 +79,10 @@ namespace Bannerlord.ButterLib.Implementation
                 ClanInitializeClanPatch.Apply(campaignIdentifierHarmony);
 
                 CampaignBehaviorManagerPatch.Apply(new Harmony("Bannerlord.ButterLib.MBObjectExtensionDataStore"));
-                TypeExtensionsPatch.Apply(new Harmony("Bannerlord.ButterLib.SaveSystem"));
+
+                var saveSystemHarmony = new Harmony("Bannerlord.ButterLib.SaveSystem");
+                TypeExtensionsPatch.Apply(saveSystemHarmony); // Adds support for saving many more container types
+                DefinitionContextPatch.Apply(saveSystemHarmony); // Fixes save corruption & crashes when duplicate types are defined
             }
 
             Logger.LogTrace("OnBeforeInitialModuleScreenSetAsRoot() finished.");

--- a/src/Bannerlord.ButterLib.Implementation/SubModule.cs
+++ b/src/Bannerlord.ButterLib.Implementation/SubModule.cs
@@ -47,7 +47,7 @@ namespace Bannerlord.ButterLib.Implementation
             services.AddSingleton<DistanceMatrixStatic, DistanceMatrixStaticImplementation>();
             services.AddSingleton<ICampaignExtensions, CampaignExtensionsImplementation>();
             services.AddTransient<ICampaignDescriptorProvider, JsonCampaignDescriptorProvider>();
-            services.AddScoped<IMBObjectVariableStorage, MBObjectVariableStorageBehavior>();
+            services.AddScoped<IMBObjectExtensionDataStore, MBObjectExtensionDataStore>();
 
             Logger.LogTrace("OnSubModuleLoad() finished.");
         }
@@ -78,9 +78,7 @@ namespace Bannerlord.ButterLib.Implementation
                 CharacterCreationContentApplyCulturePatch.Apply(campaignIdentifierHarmony);
                 ClanInitializeClanPatch.Apply(campaignIdentifierHarmony);
 
-                // Selectively apply Harmony patches for MBObjectVariableStorageBehavior load/save
-                // Moved to OnBeforeInitialModuleScreenSetAsRoot so we'll get a final logger
-                CampaignBehaviorManagerPatch.Apply(new Harmony("Bannerlord.ButterLib.MBObjectVariableStorage"));
+                CampaignBehaviorManagerPatch.Apply(new Harmony("Bannerlord.ButterLib.MBObjectExtensionDataStore"));
                 TypeExtensionsPatch.Apply(new Harmony("Bannerlord.ButterLib.SaveSystem"));
             }
 

--- a/src/Bannerlord.ButterLib/Common/Helpers/AccessTools2.cs
+++ b/src/Bannerlord.ButterLib/Common/Helpers/AccessTools2.cs
@@ -297,6 +297,7 @@ namespace Bannerlord.ButterLib.Common.Helpers
             return methodInfo is null ? null : GetDelegate<TDelegate, TInstance>(instance, methodInfo);
         }
 
+
         /// <summary>
         /// Get a delegate for an instance method directly declared by <paramref name="instance"/>'s type.
         /// Choose the overload with the given <paramref name="parameters"/> if not <see langword="null"/>

--- a/src/Bannerlord.ButterLib/Internal/MaybeNullAttribute.cs
+++ b/src/Bannerlord.ButterLib/Internal/MaybeNullAttribute.cs
@@ -1,5 +1,0 @@
-﻿namespace System.Diagnostics.CodeAnalysis
-{
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = true)]
-    internal sealed class MaybeNullAttribute : Attribute { }
-}

--- a/src/Bannerlord.ButterLib/Internal/NullableAttributes.cs
+++ b/src/Bannerlord.ButterLib/Internal/NullableAttributes.cs
@@ -1,0 +1,140 @@
+﻿#pragma warning disable MA0048 // File name must match type name
+#define INTERNAL_NULLABLE_ATTRIBUTES
+#if NETSTANDARD2_0 ||  NETCOREAPP2_0 ||  NETCOREAPP2_1 ||  NETCOREAPP2_2 || NET45 || NET451 || NET452 || NET6 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+
+// https://github.com/dotnet/corefx/blob/48363ac826ccf66fbe31a5dcb1dc2aab9a7dd768/src/Common/src/CoreLib/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+    sealed class AllowNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+    sealed class DisallowNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+    sealed class MaybeNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+    sealed class NotNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+    sealed class MaybeNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter may be null.
+        /// </param>
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+        sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+    sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+    sealed class DoesNotReturnAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+    sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified parameter value.</summary>
+        /// <param name="parameterValue">
+        /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+        /// the associated parameter matches this value.
+        /// </param>
+        public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+
+        /// <summary>Gets the condition parameter value.</summary>
+        public bool ParameterValue { get; }
+    }
+}
+#endif

--- a/src/Bannerlord.ButterLib/ObjectSystem/Extensions/MBObjectBaseExtensions.cs
+++ b/src/Bannerlord.ButterLib/ObjectSystem/Extensions/MBObjectBaseExtensions.cs
@@ -39,7 +39,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
          * <typeparam name="T">The type of the variable's value.</typeparam>
          * <param name="object">A game object.</param>
          * <param name="name">The variable's name.</param>
-         * <param name="value">The variable.</param>
+         * <param name="value">The variable value or <see langword="default"> if nonexistent.</param>
          */
         internal static bool TryGetVariable<T>(this MBObjectBase @object, string name, [MaybeNull] out T value)
         {

--- a/src/Bannerlord.ButterLib/ObjectSystem/Extensions/MBObjectBaseExtensions.cs
+++ b/src/Bannerlord.ButterLib/ObjectSystem/Extensions/MBObjectBaseExtensions.cs
@@ -69,8 +69,13 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
          * <param name="name">The variable's name.</param>
          * <param name="value">The variable value or <see langword="default"> if nonexistent.</param>
          */
-        internal static bool TryGetVariable<T>(this MBObjectBase @object, string name, [MaybeNull] out T value)
+        internal static bool TryGetVariable<T>(this MBObjectBase @object, string name, [MaybeNullWhen(false)][NotNullWhen(true)] out T value)
         {
+            if (name is null)
+                throw new ArgumentNullException(nameof(name));
+            else if (name.Length == 0)
+                throw new ArgumentException(nameof(name), "Variable name cannot be empty.");
+
             if (Instance is { } instance && instance.TryGetVariable<T>(@object, name, out var val))
             {
                 value = val;
@@ -96,15 +101,17 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
         /// <param name="data">The variable's value.</param>
         internal static void SetVariable<T>(this MBObjectBase @object, string name, T data)
         {
+            if (name is null)
+                throw new ArgumentNullException(nameof(name));
+            else if (name.Length == 0)
+                throw new ArgumentException(nameof(name), "Variable name cannot be empty.");
+
             if (Instance is { } instance)
             {
                 if (data is char @char)
-                {
                     instance.SetVariable(@object, name, @char.ToString());
-                    return;
-                }
-
-                instance.SetVariable(@object, name, data);
+                else
+                    instance.SetVariable(@object, name, data);
             }
         }
 
@@ -120,6 +127,11 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
         /// <param name="name">The variable's name.</param>
         internal static void RemoveVariable(this MBObjectBase @object, string name)
         {
+            if (name is null)
+                throw new ArgumentNullException(nameof(name));
+            else if (name.Length == 0)
+                throw new ArgumentException(nameof(name), "Variable name cannot be empty.");
+
             if (Instance is { } instance)
                 instance.RemoveVariable(@object, name);
         }
@@ -138,7 +150,15 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
         /// </example>
         /// <param name="object">A game object.</param>
         /// <param name="name">A string flag.</param>
-        public static bool HasFlag(this MBObjectBase @object, string name) => Instance is { } instance && instance.HasFlag(@object, name);
+        public static bool HasFlag(this MBObjectBase @object, string name)
+        {
+            if (name is null)
+                throw new ArgumentNullException(nameof(name));
+            else if (name.Length == 0)
+                throw new ArgumentException(nameof(name), "Flag name cannot be empty.");
+
+            return Instance is { } instance && instance.HasFlag(@object, name);
+        }
 
         /// <summary>Set the flag <paramref name="name"/> upon <paramref name="object"/>.</summary>
         /// <example>
@@ -150,6 +170,11 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
         /// <param name="name">A string flag.</param>
         public static void SetFlag(this MBObjectBase @object, string name)
         {
+            if (name is null)
+                throw new ArgumentNullException(nameof(name));
+            else if (name.Length == 0)
+                throw new ArgumentException(nameof(name), "Flag name cannot be empty.");
+
             if (Instance is { } instance)
                 instance.SetFlag(@object, name);
         }
@@ -164,6 +189,11 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
         /// <param name="name">A string flag.</param>
         public static void RemoveFlag(this MBObjectBase @object, string name)
         {
+            if (name is null)
+                throw new ArgumentNullException(nameof(name));
+            else if (name.Length == 0)
+                throw new ArgumentException(nameof(name), "Flag name cannot be empty.");
+
             if (Instance is { } instance)
                 instance.RemoveFlag(@object, name);
         }

--- a/src/Bannerlord.ButterLib/ObjectSystem/Extensions/MBObjectBaseExtensions.cs
+++ b/src/Bannerlord.ButterLib/ObjectSystem/Extensions/MBObjectBaseExtensions.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 using TaleWorlds.ObjectSystem;
@@ -9,7 +10,7 @@ using TaleWorlds.ObjectSystem;
 namespace Bannerlord.ButterLib.ObjectSystem.Extensions
 {
     /// <summary>
-    /// <see cref="MBObjectBase"/> extension methods for dynamic variable / flag storage
+    /// <see cref="MBObjectBase"/> extension methods for Object Extension Data (dynamic variable / flag storage)
     /// </summary>
     public static class MBObjectBaseExtensions
     {
@@ -21,6 +22,33 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
         internal static void OnGameEnd() => _instance = null;
 
         /* Variables */
+
+        /**
+         * <summary>
+         * Check whether a variable <paramref name="name"/> is stored upon <paramref name="object"/>.
+         * </summary>
+         * <returns>
+         * <see langword="true"/> if it exists, else <see langword="false"/>.
+         * </returns>
+         * <example>
+         * <code>
+         *  foreach (var skill in SkillObject.All)
+         *      if (!skill.HasVariable("CustomModifiers"))
+         *          RecalculateCustomModifiers(skill);
+         * </code>
+         * </example>
+         * <param name="object">A game object.</param>
+         * <param name="name">The variable's name.</param>
+         */
+        public static bool HasVariable(this MBObjectBase @object, string name)
+        {
+            if (name is null)
+                throw new ArgumentNullException(nameof(name));
+            else if (name.Length == 0)
+                throw new ArgumentException(nameof(name), "Variable name cannot be empty.");
+
+            return Instance is { } instance && instance.HasVariable(@object, name);
+        }
 
         /**
          * <summary>

--- a/src/Bannerlord.ButterLib/ObjectSystem/Extensions/MBObjectBaseExtensions.cs
+++ b/src/Bannerlord.ButterLib/ObjectSystem/Extensions/MBObjectBaseExtensions.cs
@@ -14,10 +14,10 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
     /// </summary>
     public static class MBObjectBaseExtensions
     {
-        private static IMBObjectVariableStorage? _instance;
+        private static IMBObjectExtensionDataStore? _instance;
 
-        private static IMBObjectVariableStorage? Instance =>
-            _instance ??= ButterLibSubModule.Instance?.GetServiceProvider()?.GetRequiredService<IMBObjectVariableStorage>();
+        private static IMBObjectExtensionDataStore? Instance =>
+            _instance ??= ButterLibSubModule.Instance?.GetServiceProvider()?.GetRequiredService<IMBObjectExtensionDataStore>();
 
         internal static void OnGameEnd() => _instance = null;
 

--- a/src/Bannerlord.ButterLib/ObjectSystem/Extensions/MBObjectBaseExtensions.cs
+++ b/src/Bannerlord.ButterLib/ObjectSystem/Extensions/MBObjectBaseExtensions.cs
@@ -74,7 +74,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
             if (name is null)
                 throw new ArgumentNullException(nameof(name));
             else if (name.Length == 0)
-                throw new ArgumentException(nameof(name), "Variable name cannot be empty.");
+                throw new ArgumentException("Variable name cannot be empty.", nameof(name));
 
             if (Instance is { } instance && instance.TryGetVariable<T>(@object, name, out var val))
             {
@@ -148,7 +148,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
             if (name is null)
                 throw new ArgumentNullException(nameof(name));
             else if (name.Length == 0)
-                throw new ArgumentException(nameof(name), "Variable name cannot be empty.");
+                throw new ArgumentException("Variable name cannot be empty.", nameof(name));
 
             if (Instance is { } instance)
             {
@@ -174,7 +174,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
             if (name is null)
                 throw new ArgumentNullException(nameof(name));
             else if (name.Length == 0)
-                throw new ArgumentException(nameof(name), "Variable name cannot be empty.");
+                throw new ArgumentException("Variable name cannot be empty.", nameof(name));
 
             if (Instance is { } instance)
                 instance.RemoveVariable(@object, name);
@@ -199,7 +199,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
             if (name is null)
                 throw new ArgumentNullException(nameof(name));
             else if (name.Length == 0)
-                throw new ArgumentException(nameof(name), "Flag name cannot be empty.");
+                throw new ArgumentException("Flag name cannot be empty.", nameof(name));
 
             return Instance is { } instance && instance.HasFlag(@object, name);
         }
@@ -217,7 +217,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
             if (name is null)
                 throw new ArgumentNullException(nameof(name));
             else if (name.Length == 0)
-                throw new ArgumentException(nameof(name), "Flag name cannot be empty.");
+                throw new ArgumentException("Flag name cannot be empty.", nameof(name));
 
             if (Instance is { } instance)
                 instance.SetFlag(@object, name);
@@ -236,7 +236,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
             if (name is null)
                 throw new ArgumentNullException(nameof(name));
             else if (name.Length == 0)
-                throw new ArgumentException(nameof(name), "Flag name cannot be empty.");
+                throw new ArgumentException("Flag name cannot be empty.", nameof(name));
 
             if (Instance is { } instance)
                 instance.RemoveFlag(@object, name);

--- a/src/Bannerlord.ButterLib/ObjectSystem/Extensions/MBObjectBaseExtensions.cs
+++ b/src/Bannerlord.ButterLib/ObjectSystem/Extensions/MBObjectBaseExtensions.cs
@@ -42,10 +42,10 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
          */
         public static bool HasVariable(this MBObjectBase @object, string name)
         {
-            if (name is null)
+            if (name is null!)
                 throw new ArgumentNullException(nameof(name));
             else if (name.Length == 0)
-                throw new ArgumentException(nameof(name), "Variable name cannot be empty.");
+                throw new ArgumentException("Variable name cannot be empty.", nameof(name));
 
             return Instance is { } instance && instance.HasVariable(@object, name);
         }
@@ -71,7 +71,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
          */
         internal static bool TryGetVariable<T>(this MBObjectBase @object, string name, [MaybeNullWhen(false)][NotNullWhen(true)] out T value)
         {
-            if (name is null)
+            if (name is null!)
                 throw new ArgumentNullException(nameof(name));
             else if (name.Length == 0)
                 throw new ArgumentException("Variable name cannot be empty.", nameof(name));
@@ -145,7 +145,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
          */
         internal static void SetVariable<T>(this MBObjectBase @object, string name, T data)
         {
-            if (name is null)
+            if (name is null!)
                 throw new ArgumentNullException(nameof(name));
             else if (name.Length == 0)
                 throw new ArgumentException("Variable name cannot be empty.", nameof(name));
@@ -171,7 +171,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
         /// <param name="name">The variable's name.</param>
         internal static void RemoveVariable(this MBObjectBase @object, string name)
         {
-            if (name is null)
+            if (name is null!)
                 throw new ArgumentNullException(nameof(name));
             else if (name.Length == 0)
                 throw new ArgumentException("Variable name cannot be empty.", nameof(name));
@@ -196,7 +196,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
         /// <param name="name">A string flag.</param>
         public static bool HasFlag(this MBObjectBase @object, string name)
         {
-            if (name is null)
+            if (name is null!)
                 throw new ArgumentNullException(nameof(name));
             else if (name.Length == 0)
                 throw new ArgumentException("Flag name cannot be empty.", nameof(name));
@@ -214,7 +214,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
         /// <param name="name">A string flag.</param>
         public static void SetFlag(this MBObjectBase @object, string name)
         {
-            if (name is null)
+            if (name is null!)
                 throw new ArgumentNullException(nameof(name));
             else if (name.Length == 0)
                 throw new ArgumentException("Flag name cannot be empty.", nameof(name));
@@ -233,7 +233,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
         /// <param name="name">A string flag.</param>
         public static void RemoveFlag(this MBObjectBase @object, string name)
         {
-            if (name is null)
+            if (name is null!)
                 throw new ArgumentNullException(nameof(name));
             else if (name.Length == 0)
                 throw new ArgumentException("Flag name cannot be empty.", nameof(name));

--- a/src/Bannerlord.ButterLib/ObjectSystem/Extensions/MBObjectBaseExtensions.cs
+++ b/src/Bannerlord.ButterLib/ObjectSystem/Extensions/MBObjectBaseExtensions.cs
@@ -86,19 +86,63 @@ namespace Bannerlord.ButterLib.ObjectSystem.Extensions
             return false;
         }
 
-        /// <summary>
-        /// Set the value of the variable <paramref name="name"/> upon <paramref name="object"/>
-        /// to <paramref name="data"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// myHero.SetVariable("Lovers", new List&lt;Hero&gt; { Hero.MainHero });
-        /// </code>
-        /// </example>
-        /// <typeparam name="T">Type of the variable's value.</typeparam>
-        /// <param name="object">A game object.</param>
-        /// <param name="name">The variable's name.</param>
-        /// <param name="data">The variable's value.</param>
+        /** <summary>
+         *  Set the value of the variable <paramref name="name"/> upon <paramref name="object"/>
+         *  to <paramref name="data"/>.
+         *  </summary>
+         *  <example>
+         *  <code>
+         *  // Herein, we're going to find potential lovers (non-spouse consorts) for a lover-less player Hero,
+         *  // and then we'll pick out a few and actually put them into the official Lovers variable of the player
+         *  // with SetVariable.
+         *  //
+         *  // We also assume there's already a HashSet&lt;Hero&gt;-type variable called AttractedTo which is
+         *  // already set on all heroes that are theoretically eligible to marry the player.
+         *
+         *  // Example is for setting a variable outright rather than modifying a retrieved one by reference, so this is only
+         *  // for lover-less players. Modifying existing variables directly by reference is shown at the end.
+         *  if (Hero.MainHero.HasVariable("Lovers"))
+         *      return;
+         *
+         *  // Find possible lovers for the player Hero
+         *  var possibleLovers = Hero.All.Where(h =&gt; h.IsAlive &amp;&amp; // Pretty gross otherwise
+         *                                           Math.Abs(Hero.MainHero.Age - h.Age) &lt; 15f &amp;&amp; // Less than 15 year age gap
+         *                                           // By game rules, whether the character could legally marry the player someday:
+         *                                           Campaign.Current.Models.MarriageModel.IsCoupleSuitableForMarriage(Hero.MainHero, h) &amp;&amp;
+         *                                           // Only those that are attracted to the player (uses another variable, a set of heroes):
+         *                                           h.TryGetVariable("AttractedTo", out HashSet&lt;Hero&gt; attractionSet) &amp;&amp;
+         *                                           attractionSet.Contains(Hero.MainHero) &amp;&amp;
+         *                                           // The attraction must be mutual:
+         *                                           Hero.MainHero.TryGetVariable("AttractedTo", out HashSet&lt;Hero&gt; playerAttractionSet) &amp;&amp;
+         *                                           playerAttractionSet.Contains(h)
+         *                                           );
+         *
+         *  // Take [up to] the 5 youngest of the possible lovers (results in a List&lt;Hero&gt;)
+         *  var lovers = possibleLovers.OrderBy(h =&gt; h.Age).Take(5).ToList();
+         *
+         *  // Set these lovers into the player's variable named "Lovers"
+         *  Hero.MainHero.SetVariable("Lovers", lovers);
+         *
+         *  // Being lovers goes both ways (i.e., if A is B's lover, then B is A's lover):
+         *  foreach (var lover in lovers)
+         *  {
+         *      // Append the player to any potential preexisting lovers that this new lover may have,
+         *      // else set a new Lovers variable upon them which contains only the player.
+         *
+         *      // NOTE: This demonstrates modification of an existing variable by reference, which
+         *      //       often bypasses the need to actually use SetVariable:
+         *      if (lover.TryGetVariable("Lovers", out List&lt;Hero&gt; theirLovers))
+         *          theirLovers.Add(Hero.MainHero); // Modify existing variable by reference
+         *      else
+         *          lover.SetVariable("Lovers", new List&lt;Hero&gt; { Hero.MainHero }); // If var doesn't exist, forced to SetVariable
+         *  }
+         *  </code>
+         *  </example>
+         *  <typeparam name="T">Type of the variable's value.</typeparam>
+         *  <param name="object">A game object.</param>
+         *  <param name="name">The variable's name.</param>
+         *  <param name="data">The variable's value.</param>
+         */
         internal static void SetVariable<T>(this MBObjectBase @object, string name, T data)
         {
             if (name is null)

--- a/src/Bannerlord.ButterLib/ObjectSystem/IMBObjectExtensionDataStore.cs
+++ b/src/Bannerlord.ButterLib/ObjectSystem/IMBObjectExtensionDataStore.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 using TaleWorlds.ObjectSystem;
 
@@ -11,7 +10,7 @@ namespace Bannerlord.ButterLib.ObjectSystem
      * Used primarily by <see cref="Extensions.MBObjectBaseExtensions"/>.
      * </summary>
      */
-    internal interface IMBObjectVariableStorage
+    internal interface IMBObjectExtensionDataStore
     {
         /****    V A R I A B L E S    ****/
 

--- a/src/Bannerlord.ButterLib/ObjectSystem/IMBObjectVariableStorage.cs
+++ b/src/Bannerlord.ButterLib/ObjectSystem/IMBObjectVariableStorage.cs
@@ -1,15 +1,53 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 using TaleWorlds.ObjectSystem;
 
 namespace Bannerlord.ButterLib.ObjectSystem
 {
-    /// <summary>
-    /// Interface to <see cref="MBObjectBase"/>-associated dynamic variable / flag storage
-    /// </summary>
+    /**
+     * <summary>
+     * Storage interface to <see cref="MBObjectBase"/>-associated Object Extension Data (dynamic variables / flags).
+     * Used primarily by <see cref="Extensions.MBObjectBaseExtensions"/>.
+     * </summary>
+     */
     internal interface IMBObjectVariableStorage
     {
-        /* Variables */
+        /****    V A R I A B L E S    ****/
+
+        /**
+         * <summary>
+         * Check whether a variable <paramref name="name"/> is stored upon <paramref name="object"/>.
+         * </summary>
+         * <returns>
+         * <see langword="true"/> if it exists, else <see langword="false"/>.
+         * </returns>
+         * <param name="object">A game object.</param>
+         * <param name="name">The variable's name.</param>
+         */
+        internal bool HasVariable(MBObjectBase @object, string name);
+
+        /**
+         * <summary>
+         * Remove the variable <paramref name="name"/> from <paramref name="object"/>, if set.
+         * </summary>
+         * <returns>
+         * <see langword="true"/> if it was set prior to removal, else <see langword="false"/>.
+         * </returns>
+         * <param name="object">A game object.</param>
+         * <param name="name">The variable's name.</param>
+         */
+        internal bool RemoveVariable(MBObjectBase @object, string name);
+
+        /**
+         * <summary>
+         * Set the value of the variable <paramref name="name"/> upon <paramref name="object"/> to <paramref name="data"/>.
+         * </summary>
+         * <param name="object">A game object.</param>
+         * <param name="name">The variable's name.</param>
+         * <param name="data">The variable's value.</param>
+         */
+        internal void SetVariable(MBObjectBase @object, string name, object? data);
 
         /**
          * <summary>
@@ -23,44 +61,41 @@ namespace Bannerlord.ButterLib.ObjectSystem
          * <param name="object">A game object.</param>
          * <param name="name">The variable's name.</param>
          */
-        public bool TryGetVariable<T>(MBObjectBase @object, string name, [MaybeNull] out T value);
+        internal bool TryGetVariable<T>(MBObjectBase @object, string name, [NotNullWhen(true)] out T value);
+
+        /****    F L A G S    ****/
 
         /**
          * <summary>
-         * Set the value of the variable <paramref name="name"/> upon <paramref name="object"/>
-         * to <paramref name="data"/>.
+         * Check whether the flag <paramref name="name"/> is set upon <paramref name="object"/>.
+         * </summary>
+         * <returns>
+         * <see langword="true"/> if set, else <see langword="false"/>.
+         * </returns>
+         * <param name="object">A game object.</param>
+         * <param name="name">A string flag.</param>
+         */
+        internal bool HasFlag(MBObjectBase @object, string name);
+
+        /**
+         * <summary>
+         * Remove the flag <paramref name="name"/> from <paramref name="object"/>, if set.
+         * </summary>
+         * <returns>
+         * <see langword="true"/> if it was set prior to removal, else <see langword="false"/>.
+         * </returns>
+         * <param name="object">A game object.</param>
+         * <param name="name">A string flag.</param>
+         */
+        internal bool RemoveFlag(MBObjectBase @object, string name);
+
+        /**
+         * <summary>
+         * Set the flag <paramref name="name"/> upon <paramref name="object"/>.
          * </summary>
          * <param name="object">A game object.</param>
-         * <param name="name">The variable's name.</param>
-         * <param name="data">The variable's value.</param>
+         * <param name="name">A string flag.</param>
          */
-        public void SetVariable(MBObjectBase @object, string name, object? data);
-
-        /// <summary>
-        /// Remove the variable <paramref name="name"/> from <paramref name="object"/>, if set.
-        /// </summary>
-        /// <param name="object">A game object.</param>
-        /// <param name="name">The variable's name.</param>
-        public void RemoveVariable(MBObjectBase @object, string name);
-
-        /* Flags */
-
-        /// <summary>
-        /// Check whether the flag <paramref name="name"/> is set upon <paramref name="object"/>.
-        /// </summary>
-        /// <returns><see langword="true"/> if the flag is set, else <see langword="false"/>.</returns>
-        /// <param name="object">A game object.</param>
-        /// <param name="name">A string flag.</param>
-        public bool HasFlag(MBObjectBase @object, string name);
-
-        /// <summary>Set the flag <paramref name="name"/> upon <paramref name="object"/>.</summary>
-        /// <param name="object">A game object.</param>
-        /// <param name="name">A string flag.</param>
         public void SetFlag(MBObjectBase @object, string name);
-
-        /// <summary>Remove the flag <paramref name="name"/> from <paramref name="object"/>, if set.</summary>
-        /// <param name="object">A game object.</param>
-        /// <param name="name">A string flag.</param>
-        public void RemoveFlag(MBObjectBase @object, string name);
     }
 }

--- a/tests/Bannerlord.ButterLib.ObjectSystem.Test/Bannerlord.ButterLib.ObjectSystem.Test.csproj
+++ b/tests/Bannerlord.ButterLib.ObjectSystem.Test/Bannerlord.ButterLib.ObjectSystem.Test.csproj
@@ -4,13 +4,11 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <LangVersion>9.0</LangVersion>
+    <PlatformTarget>x64</PlatformTarget>
     <Nullable>enable</Nullable>
-
-    <Configurations>Stable_Debug;Stable_Release;Beta_Debug;Beta_Release</Configurations>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-
+    <Configurations>Stable_Debug;Stable_Release;Beta_Debug;Beta_Release</Configurations>
     <ModuleName>Bannerlord.ButterLib.ObjectSystem.Test</ModuleName>
   </PropertyGroup>
 

--- a/tests/Bannerlord.ButterLib.ObjectSystem.Test/Bannerlord.ButterLib.ObjectSystem.Test.csproj
+++ b/tests/Bannerlord.ButterLib.ObjectSystem.Test/Bannerlord.ButterLib.ObjectSystem.Test.csproj
@@ -14,13 +14,6 @@
     <ModuleName>Bannerlord.ButterLib.ObjectSystem.Test</ModuleName>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <StartAction>Program</StartAction>
-    <StartProgram>$(GameFolder)\bin\Win64_Shipping_Client\Bannerlord.exe</StartProgram>
-    <StartArguments>/singleplayer _MODULES_*Bannerlord.Harmony*Bannerlord.ButterLib*Native*SandBoxCore*SandBox*StoryMode*CustomBattle*$(ModuleName)*_MODULES_</StartArguments>
-    <StartWorkingDirectory>$(GameFolder)\bin\Win64_Shipping_Client</StartWorkingDirectory>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Bannerlord.BuildResources" Version="$(BuildResourcesVersion)">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Bannerlord.ButterLib.ObjectSystem.Test/Properties/launchSettings.json
+++ b/tests/Bannerlord.ButterLib.ObjectSystem.Test/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Bannerlord.ButterLib.ObjectSystem.Test": {
+      "commandName": "Executable",
+      "executablePath": "F:\\SteamLibrary\\steamapps\\common\\Mount & Blade II Bannerlord\\bin\\Win64_Shipping_Client\\Bannerlord.exe",
+      "commandLineArgs": "/singleplayer _MODULES_*Bannerlord.Harmony*Bannerlord.ButterLib*Bannerlord.UIExtenderEx*Bannerlord.MBOptionScreen*Native*SandBoxCore*SandBox*StoryMode*CustomBattle*Bannerlord.ButterLib.ObjectSystem.Test*_MODULES_",
+      "workingDirectory": "F:\\SteamLibrary\\steamapps\\common\\Mount & Blade II Bannerlord\\bin\\Win64_Shipping_Client"
+    }
+  }
+}

--- a/tests/Bannerlord.ButterLib.ObjectSystem.Test/SubModule.cs
+++ b/tests/Bannerlord.ButterLib.ObjectSystem.Test/SubModule.cs
@@ -11,7 +11,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Test
 {
     public sealed class SubModule : MBSubModuleBase
     {
-        private const string Version = "Rev. 4";
+        private const string Version = "Rev. 5";
         private bool _hasLoaded;
 
         private ILogger _logger = default!;

--- a/tests/Bannerlord.ButterLib.ObjectSystem.Test/SubModule.cs
+++ b/tests/Bannerlord.ButterLib.ObjectSystem.Test/SubModule.cs
@@ -11,7 +11,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Test
 {
     public sealed class SubModule : MBSubModuleBase
     {
-        private const string Version = "Rev. 3";
+        private const string Version = "Rev. 4";
         private bool _hasLoaded;
 
         private ILogger _logger = default!;

--- a/tests/Bannerlord.ButterLib.ObjectSystem.Test/TestCampaignBehavior.cs
+++ b/tests/Bannerlord.ButterLib.ObjectSystem.Test/TestCampaignBehavior.cs
@@ -2,8 +2,6 @@
 using Bannerlord.ButterLib.Logger.Extensions;
 using Bannerlord.ButterLib.ObjectSystem.Extensions;
 
-using Messages.FromLobbyServer.ToClient;
-
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/Bannerlord.ButterLib.ObjectSystem.Test/TestCampaignBehavior.cs
+++ b/tests/Bannerlord.ButterLib.ObjectSystem.Test/TestCampaignBehavior.cs
@@ -55,7 +55,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Test
                     {
                         _log.LogTrace($"Errant Hero: {GetHeroTrace(h)} / Object: {GetObjectTrace(h)}");
                         _log.LogError("Halting execution due to error(s).");
-                        _log.LogWarningAndDisplay("<<<<<  STORE FAILED!  >>>>>");
+                        _log.LogInformationAndDisplay("     <<<<<  STORE FAILED!  >>>>>");
                         return;
                     }
                 }
@@ -63,7 +63,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Test
             else
                 Hero.MainHero.SetVariable("Identity", GetHeroTrace(Hero.MainHero));
 
-            _log.LogWarningAndDisplay("<<<<<  STORE PASSED!  >>>>>");
+            _log.LogInformationAndDisplay("     <<<<<  STORE PASSED!  >>>>>");
         }
 
         protected void OnGameLoaded(CampaignGameStarter starter)
@@ -94,7 +94,7 @@ namespace Bannerlord.ButterLib.ObjectSystem.Test
                 pass &= TestRefVarByValue(name, want, got);
             }
 
-            _log.LogWarningAndDisplay(pass ? "<<<<<  TEST PASSED!  >>>>>" : "<<<<<  TEST FAILED!  >>>>>");
+            _log.LogInformationAndDisplay(pass ? "   <<<<<  TEST PASSED!  >>>>>" : "   <<<<<  TEST FAILED!  >>>>>");
         }
 
         private void SetOrValidateHeroVars(Hero h, bool store)
@@ -130,14 +130,14 @@ namespace Bannerlord.ButterLib.ObjectSystem.Test
             }
         }
 
-        public class SaveableTypeDefiner : TaleWorlds.SaveSystem.SaveableTypeDefiner
+        public class SavedTypeDefiner : SaveableCampaignBehaviorTypeDefiner
         {
-            public CustomSaveTypeDefiner() : base(222_444_600) { }
+            public SavedTypeDefiner() : base(222_444_600) { }
 
             protected override void DefineClassTypes()
             {
                 AddClassDefinition(typeof(HeroTest), 1);
-                AddClassDefinition(typeof(WrappedDictionary), 3);
+                //AddClassDefinition(typeof(WrappedDictionary), 3);
             }
 
             protected override void DefineEnumTypes() => AddEnumDefinition(typeof(ElectionCandidate), 2);
@@ -211,28 +211,28 @@ namespace Bannerlord.ButterLib.ObjectSystem.Test
                 #endregion DisabledCircularReferenceTest
             }
 
-            [SaveableField(1)]
+            [SaveableField(0)]
             internal readonly Hero Hero; // internal readonly ref
 
-            [SaveableProperty(2)]
+            [SaveableProperty(1)]
             internal int Age { get; set; } // uh, if THIS doesn't work...
 
-            [SaveableField(3)]
+            [SaveableField(2)]
             private readonly Hero? Spouse; // private readonly ref
 
-            [SaveableProperty(4)]
+            [SaveableProperty(3)]
             internal Kingdom? Kingdom { get; private set; } // private setter
 
-            [SaveableField(5)]
+            [SaveableField(4)]
             internal readonly BodyProperties BodyProperties; // a readonly struct
 
-            [SaveableField(6)]
+            [SaveableField(5)]
             internal TextObject NameLink; // a complex ref type that's not MBObjectBase
 
-            [SaveableField(7)]
+            [SaveableField(6)]
             internal Hero.CharacterStates StateEnum; // a game enum
 
-            [SaveableField(8)]
+            [SaveableField(7)]
             internal ElectionCandidate CustomEnum; // custom enum
 
             #region DisabledCircularReferenceTest
@@ -248,11 +248,11 @@ namespace Bannerlord.ButterLib.ObjectSystem.Test
         private enum ElectionCandidate { Trump = 0, Biden = 1, Kanye = 2 };
 
         //[SaveableClass(3)]
-        public class WrappedDictionary
-        {
-            [SaveableProperty(1)]
-            public Dictionary<string, string> Dictionary { get; set; } = new Dictionary<string, string>();
-        }
+        //public class WrappedDictionary
+        //{
+        //    [SaveableProperty(0)]
+        //    public Dictionary<string, string> Dictionary { get; set; } = new Dictionary<string, string>();
+        //}
 
         #region DisabledCircularReferenceTest
         //[SaveableClass(4)]

--- a/tests/Bannerlord.ButterLib.ObjectSystem.Test/_Module/SubModule.xml
+++ b/tests/Bannerlord.ButterLib.ObjectSystem.Test/_Module/SubModule.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Module>
-  <Name value="ButterLib SaveSystem Test" />
-  <Id value="Bannerlord.ButterLib.SaveSystem.Test" />
+  <Name value="ButterLib ObjectSystem Test" />
+  <Id value="Bannerlord.ButterLib.ObjectSystem.Test" />
   <Version value="v$version$" />
   <Official value="false" />
   <DefaultModule value="false" />
@@ -25,9 +25,9 @@
   <!-- Prototype -->
   <SubModules>
     <SubModule>
-      <Name value="ButterLib SaveSystem Test" />
-      <DLLName value="Bannerlord.ButterLib.SaveSystem.Test.dll" />
-      <SubModuleClassType value="Bannerlord.ButterLib.SaveSystem.Test.SubModule" />
+      <Name value="ButterLib ObjectSystem Test" />
+      <DLLName value="Bannerlord.ButterLib.ObjectSystem.Test.dll" />
+      <SubModuleClassType value="Bannerlord.ButterLib.ObjectSystem.Test.SubModule" />
       <Tags />
     </SubModule>
   </SubModules>


### PR DESCRIPTION
Will delete OED-SyncData, which kind of spiraled into a few topics, and start working on specific topic branches with my remaining work -- like a sane developer that doesn't like to spend a couple confusing hours rebasing commits.

Status:
- OED & its test are in a fine state, but the test hasn't been run on the latest code yet (but it does work w/ `ConcurrentDictionary<,>` now with the SaveSystem.
- OED's fully internalized
- AccessTools2 docs revamped & additional methods added (plan on some more)
- OED Flags API properly extension methods
- `ObjectSystem.Test` greatly simplified through the magic of helper methods that can form expressions
- Added `HasVariable` to OED API
- OED's `RemoveFlag` and `RemoveVariable` now return the preexistence of the var before removal
- OED API now [in the correct parameter order] enforces non-nullity/non-empty of required params (throws)
- Patched SaveSystem to support at least 17 .NET standard container types (vs. original 4) plus any 3rd-party types that implement the necessary interfaces
- OED got a livacious lovers extended sample code for `SetVariable` in XMLDocs
- Patched SaveSystem to be incapable of registering a duplicate type and consequently both corrupting the savegame and then crashing when trying to load it
  - In the process, started trying out some instrumentation for Harmony patching
- Patched SaveSystem to actually check whether the container type definition being constructed by a `SaveableTypeDefiner` is actually a supported container so that it doesn't crash later
- Misc. changes to nomenclature and a lot of nullability improvements