### PR TITLE
Fixed exception handler preventing debuggers from catching exceptions

### DIFF
--- a/src/Bannerlord.ButterLib/ExceptionHandler/BEWPatch.cs
+++ b/src/Bannerlord.ButterLib/ExceptionHandler/BEWPatch.cs
@@ -65,9 +65,6 @@ internal sealed class BEWPatch
     {
         if (__exception is not null)
         {
-            if (ExceptionHandlerSubSystem.Instance?.DisableWhenDebuggerIsAttached == true && IsDebuggerAttached())
-                return;
-
             ExceptionReporter.Show(__exception);
         }
     }

--- a/src/Bannerlord.ButterLib/ExceptionHandler/ExceptionHandlerSubSystem.cs
+++ b/src/Bannerlord.ButterLib/ExceptionHandler/ExceptionHandlerSubSystem.cs
@@ -78,6 +78,8 @@ internal sealed class ExceptionHandlerSubSystem : ISubSystem, ISubSystemSettings
 
         if (!BEWPatch.IsDebuggerAttached())
             SubscribeToUnhandledException();
+        else if (Instance?.DisableWhenDebuggerIsAttached == true)
+            return;
 
         if (!_wasButrLoaderInterceptorCalled)
         {


### PR DESCRIPTION
Making finalizer patches on methods automatically prevents debuggers from properly catching exceptions on them, just not showing the exception report on the finalizer does not work to allow debuggers catching the error, so the simple solution is, if DisableWhenDebuggerIsAttached  is enabled and a debugger is attached, not making the patches.
Before for me the debugger was stopping and showing CORDBG_E_CODE_NOT_AVAILABLE when the error occurred now it manages to show the exception line